### PR TITLE
[12.0] openapi: added CORS headers to response

### DIFF
--- a/openapi/README.rst
+++ b/openapi/README.rst
@@ -59,6 +59,7 @@ Contributors
 * `Ivan Yelizariev <https://it-projects.info/team/yelizariev>`__
 * `Rafis Bikbov <https://it-projects.info/team/RafiZz>`__
 * `Stanislav Krotov <https://it-projects.info/team/ufaks>`__
+* `Eugene Molotov <https://it-projects.info/team/em230418>`__
 
 Sponsors
 --------

--- a/openapi/__manifest__.py
+++ b/openapi/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "",
     # "live_test_url": "",
     "images": ["images/openapi-swagger.png"],
-    "version": "12.0.1.1.10",
+    "version": "12.0.1.1.11",
     "application": False,
     "author": "IT-Projects LLC, Ivan Yelizariev",
     "support": "sync@it-projects.info",

--- a/openapi/controllers/apijsonrequest.py
+++ b/openapi/controllers/apijsonrequest.py
@@ -98,7 +98,12 @@ class ApiJsonRequest(WebRequest):
         return Response(
             body,
             status=status,
-            headers=[("Content-Type", mime), ("Content-Length", len(body))],
+            headers=[
+                ("Access-Control-Allow-Origin", "*"),
+                ("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH"),
+                ("Content-Type", mime),
+                ("Content-Length", len(body)),
+            ],
         )
 
     def _handle_exception(self, exception):

--- a/openapi/controllers/pinguin.py
+++ b/openapi/controllers/pinguin.py
@@ -114,6 +114,10 @@ def successful_response(status, data=None):
 
     return werkzeug.wrappers.Response(
         status=status,
+        headers=[
+            ("Access-Control-Allow-Origin", "*"),
+            ("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH"),
+        ],
         content_type="application/json; charset=utf-8",
         response=response,
     )
@@ -136,6 +140,10 @@ def error_response(status, error, error_descrip):
     return werkzeug.wrappers.Response(
         status=status,
         content_type="application/json; charset=utf-8",
+        headers=[
+            ("Access-Control-Allow-Origin", "*"),
+            ("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH"),
+        ],
         response=json.dumps({"error": error, "error_descrip": error_descrip}),
     )
 

--- a/openapi/doc/changelog.rst
+++ b/openapi/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.1.11`
+--------
+
+- **Improvement:** CORS headers are added to response
+
 `1.1.10`
 --------
 

--- a/openapi/tests/test_api.py
+++ b/openapi/tests/test_api.py
@@ -46,7 +46,19 @@ class TestAPI(HttpCase):
 
     def request_from_user(self, user, *args, **kwargs):
         kwargs["auth"] = requests.auth.HTTPBasicAuth(self.db_name, user.openapi_token)
-        return self.request(*args, **kwargs)
+        response = self.request(*args, **kwargs)
+        self.assertEqual(response.headers["Access-Control-Allow-Origin"], "*")
+        allowed_methods = list(
+            map(
+                lambda x: x.strip(),
+                response.headers["Access-Control-Allow-Methods"].split(","),
+            )
+        )
+        self.assertIn("GET", allowed_methods)
+        self.assertIn("POST", allowed_methods)
+        self.assertIn("PATCH", allowed_methods)
+        self.assertIn("PUT", allowed_methods)
+        return response
 
     def test_read_many_all(self):
         resp = self.request_from_user(self.demo_user, "GET", "/{model}")


### PR DESCRIPTION
https://ru.wikipedia.org/wiki/Cross-origin_resource_sharing
Актульно как-минимум, когда разработчик делает гибридное (HTML+JS) мобильное приложение, тестирует на браузере, пытается использовать методы из OpenAPI и обламывается потому-что браузер запрещает.