### PR TITLE
:book: Tiny fixup in README

### DIFF
--- a/sync/doc/index.rst
+++ b/sync/doc/index.rst
@@ -12,14 +12,12 @@ Installation
 
   * add ``queue_job`` to `server wide modules <https://odoo-development.readthedocs.io/en/latest/admin/server_wide_modules.html>`__, e.g.::
 
-        ``--load base,web,queue_job``
+        --load base,web,queue_job
 
 * `Install <https://odoo-development.readthedocs.io/en/latest/odoo/usage/install-module.html>`__ this module in a usual way
 * Install python package that you need to use. For example, to try demo projects install following packages:
 
-    sudo pip3 install python-telegram-bot
-    sudo pip3 install PyGithub
-    sudo pip3 install py-trello
+    python3 -m pip install python-telegram-bot PyGithub py-trello
 
 * If your Sync projects use webhooks (most likely), be sure that url opens correct database without asking to select one
 


### PR DESCRIPTION
По поводу `sudo pip3 install`. В целом так делать не надо.
- Был какой-то шуточный модуль, которые проверял, если установил этот модуль от рута, то твой диск будет отформатирован через 3... 2.. 1... Это конкретно к sudo.
- python3 -m pip будет использовать pip из того-же окружения, что и python3. pip3 может быть вообще из другого окружения. У кого-то такие вещи возникали и долго не врубались, ибо "ну я же установил его".