### PR TITLE
[12.0] sync: Tiny fixup in README

### DIFF
--- a/sync/doc/index.rst
+++ b/sync/doc/index.rst
@@ -12,14 +12,12 @@ Installation
 
   * add ``queue_job`` to `server wide modules <https://odoo-development.readthedocs.io/en/latest/admin/server_wide_modules.html>`__, e.g.::
 
-        ``--load base,web,queue_job``
+        --load base,web,queue_job
 
 * `Install <https://odoo-development.readthedocs.io/en/latest/odoo/usage/install-module.html>`__ this module in a usual way
 * Install python package that you need to use. For example, to try demo projects install following packages:
 
-    sudo pip3 install python-telegram-bot
-    sudo pip3 install PyGithub
-    sudo pip3 install py-trello
+    python3 -m pip install python-telegram-bot==12.8 PyGithub py-trello
 
 * If your Sync projects use webhooks (most likely), be sure that url opens correct database without asking to select one
 


### PR DESCRIPTION
Помимо https://github.com/itpp-labs/sync-addons/pull/205 тут также фиксирую версию для python-telegram-bot, который может запускаться на python 3.5, который в свою учередь используется в официальном образе odoo для 12.0.

У Рамиля в кухне 27 ноября 2020 года была проблема из-за новой версии python-telegram-bot