### PR TITLE
[12.0] sync_1c: fix example OData URL

### DIFF
--- a/sync_1c/doc/index.rst
+++ b/sync_1c/doc/index.rst
@@ -18,7 +18,7 @@
   * Задайте логин и пароль
 * Нажмите кнопку ``Сохранить``
 
-OData must be accessible via internet. For 1cfresh instances ODATA_URL should be something like this: https://1cfresh.com/a/ea_demo/123456/odata/standard.odata/
+OData must be accessible via internet. For 1cfresh instances ODATA_URL should be something like this: https://1cfresh.com/a/sbm/123456/odata/standard.odata/
 
 To work with employee syncing:
 


### PR DESCRIPTION
Проверил работу.
Успешный запрос с исправленой ссылкой:
![Снимок экрана_2021-02-27_13-19-52](https://user-images.githubusercontent.com/52414052/109381845-81d24700-78fe-11eb-822d-9837042f4f2b.png)
Облом с изначальной:
![Снимок экрана_2021-02-27_13-18-41](https://user-images.githubusercontent.com/52414052/109381846-839c0a80-78fe-11eb-8130-68b9a2514e90.png)

