### PR TITLE
[13.0] sync_telegram: message from telegram to odoo was not attached to channel

### DIFF
--- a/sync_telegram/__manifest__.py
+++ b/sync_telegram/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": """Telegram integration powered by Sync Studio""",
     "category": "Discuss",
     "images": ["images/sync_telegram.jpg"],
-    "version": "13.0.4.1.1",
+    "version": "13.0.4.1.2",
     "application": False,
     "author": "IT Projects Labs, Ilya Ilchenko",
     "support": "help@itpp.dev",

--- a/sync_telegram/data/sync_project_data.xml
+++ b/sync_telegram/data/sync_project_data.xml
@@ -189,7 +189,7 @@ def handle_webhook(httprequest):
 
 
     channel.message_post(body=odoo_message_text, attachments=[file_bin_data], author_id=partner_link.odoo.id,
-    message_type="comment", subtype_xmlid="mail.mt_comment")
+    message_type="comment", subtype_xmlid="mail.mt_comment", channel_ids=channel.ids)
 
 
 

--- a/sync_telegram/doc/changelog.rst
+++ b/sync_telegram/doc/changelog.rst
@@ -1,3 +1,8 @@
+`4.1.2`
+-------
+
+- **Fix:** message from telegram to odoo was not attached to channel
+
 `4.1.1`
 -------
 


### PR DESCRIPTION
Когда портировал sync_telegram, я не убедился что сообщения из телеги приходят в оду.
Собственно клиент, которому портировал сам решил эту проблему и его решение загружаю сюда.

До этого пробовал более универсальное решение, где в модуле multi_livechat в метод message_post модели mail.channel добавляю нужное значение channel_ids. Но после такого решения сообщения из оду не приходят в телегу. Само универсальное решение выглядело примерно вот так:
```diff
diff --git a/multi_livechat/models/mail_channel.py b/multi_livechat/models/mail_channel.py
index 60720c6..1d458f5 100644
--- a/multi_livechat/models/mail_channel.py
+++ b/multi_livechat/models/mail_channel.py
@@ -89,11 +89,3 @@ class MailChannel(models.Model):
                 if key not in ODOO_CHANNEL_TYPES
             }
         }
+
+   @api.returns('mail.message', lambda value: value.id)
+    def message_post(self, *args, **kwargs):
+        if (self.channel_type or "").startswith("multi_livechat_"):
+            channel_ids = kwargs.get("channel_ids", [])
+            channel_ids = list(set(channel_ids + [self.id]))
+            kwargs["channel_ids"] = channel_ids
+        return super(MailChannel, self).message_post(*args, **kwargs)
```