### PR TITLE
[13.0] Корректная работа sync_telegram

### DIFF
--- a/multi_livechat/__manifest__.py
+++ b/multi_livechat/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """Be in touch with your partners via any supported channels (Telegram, WhatsApp, Instragram, etc.)""",
     "category": "Marketing",
     "images": ["images/multi_livechat.jpg"],
-    "version": "13.0.1.1.2",
+    "version": "13.0.1.2.0",
     "application": False,
     "author": "IT Projects Labs, Ivan Yelizariev",
     "support": "help@itpp.dev",

--- a/multi_livechat/doc/changelog.rst
+++ b/multi_livechat/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.2.0`
+-------
+
+- **Improvement:** allow extra keyword arguments for post_channel_message
+
 `1.1.2`
 -------
 

--- a/multi_livechat/tools.py
+++ b/multi_livechat/tools.py
@@ -71,13 +71,14 @@ def get_multi_livechat_eval_context(env, channel_type, eval_context):
             record._name,
         )
 
-    def post_channel_message(channel, message, author=None):
+    def post_channel_message(channel, message, author=None, **kwargs):
         log("Post message to {}:\n{}".format(channel, message), LOG_DEBUG)
         channel.message_post(
             body=message,
             author_id=author or odoobot_id,
             message_type="comment",
             subtype="mail.mt_comment",
+            **kwargs,
         )
 
     return {

--- a/sync_telegram/__manifest__.py
+++ b/sync_telegram/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": """Telegram integration powered by Sync Studio""",
     "category": "Discuss",
     "images": ["images/sync_telegram.jpg"],
-    "version": "13.0.4.1.2",
+    "version": "13.0.4.2.0",
     "application": False,
     "author": "IT Projects Labs, Ilya Ilchenko",
     "support": "help@itpp.dev",

--- a/sync_telegram/data/sync_project_data.xml
+++ b/sync_telegram/data/sync_project_data.xml
@@ -151,11 +151,11 @@ def handle_webhook(httprequest):
         record_model = env[params.CHAT_MODEL].with_user(main_operator).create({"name": record_name, "partner_id": partner_link.odoo.id})
         record_model.set_link(model_rel, telegram_user_ref, sync_date=None, allow_many2many=False)
 
-        record_model.message_post(body="""<b><a href="/web#action=%s&active_id=mail.channel_%s">Chat with partner is created. </a></b>""" %
-        (env.ref("mail.action_discuss").id, channel.id), author_id=odoobot_id, message_type="comment", subtype_xmlid="mail.mt_comment")
+        multi_livechat.post_channel_message(channel, """<b><a href="/web#action=%s&active_id=mail.channel_%s">Chat with partner is created. </a></b>""" %
+        (env.ref("mail.action_discuss").id, channel.id))
 
-        channel.message_post(body="""<b><a href="/web#id=%s&model=%s">Record is created. </a></b>""" %
-        (record_model.id, record_model._name), author_id=odoobot_id, message_type="comment", subtype_xmlid="mail.mt_comment")
+        multi_livechat.post_channel_message(channel, """<b><a href="/web#id=%s&model=%s">Record is created. </a></b>""" %
+        (record_model.id, record_model._name))
 
     file_bin_data = []
     telegram_document = update.message.document
@@ -178,18 +178,15 @@ def handle_webhook(httprequest):
             file_bin_data = telegram.getDocumentFile(telegram_user_ref, telegram_document)
 
         elif telegram_photo or telegram_media or telegram_document:
-            channel.message_post(body="Incoming file is too big and cannot be downloaded due to Telegram API restirctions",
-            author_id=odoobot_id, message_type="comment", subtype_xmlid="mail.mt_comment")
+            multi_livechat.post_channel_message(channel, "Incoming file is too big and cannot be downloaded due to Telegram API restirctions")
             telegram.sendMessage(telegram_user_ref, "File is too big, file size must not exceed 20 MB.")
 
         if telegram_sticker:
             log("telegram_sticker: %s" % telegram_sticker, LOG_INFO)
-            channel.message_post(body=telegram_sticker.emoji, author_id=partner_link.odoo.id,
-            message_type="comment", subtype_xmlid="mail.mt_comment")
+            multi_livechat.post_channel_message(channel, telegram_sticker.emoji, author=partner_link.odoo.id)
 
 
-    channel.message_post(body=odoo_message_text, attachments=[file_bin_data], author_id=partner_link.odoo.id,
-    message_type="comment", subtype_xmlid="mail.mt_comment", channel_ids=channel.ids)
+    multi_livechat.post_channel_message(channel, odoo_message_text, attachments=[file_bin_data], author=partner_link.odoo.id)
 
 
 

--- a/sync_telegram/doc/changelog.rst
+++ b/sync_telegram/doc/changelog.rst
@@ -1,3 +1,8 @@
+`4.2.0`
+-------
+
+- **Improvement:** refactor to use common method to post messages on channel
+
 `4.1.2`
 -------
 

--- a/sync_telegram/models/sync_project.py
+++ b/sync_telegram/models/sync_project.py
@@ -15,6 +15,7 @@ from telegram import (  # pylint: disable=missing-manifest-dependency; disabled 
 
 from odoo import api, fields, models
 
+from odoo.addons.multi_livechat.tools import get_multi_livechat_eval_context
 from odoo.addons.sync.models.sync_project import AttrDict
 
 _logger = logging.getLogger(__name__)
@@ -39,6 +40,8 @@ class SyncProjectTelegram(models.Model):
         * telegram.sendMessage
         * telegram.setWebhook
         * telegram.parse_data
+
+        * multi_livechat.*
         """
 
         log_transmission = eval_context["log_transmission"]
@@ -121,6 +124,11 @@ class SyncProjectTelegram(models.Model):
         def parse_data(data):
             return Update.de_json(data, bot)
 
+        multi_livechat_context = AttrDict(
+            get_multi_livechat_eval_context(
+                self.env, "multi_livechat_telegram", eval_context
+            )
+        )
         telegram = AttrDict(
             {
                 "sendMessage": sendMessage,
@@ -141,4 +149,5 @@ class SyncProjectTelegram(models.Model):
         return {
             "telegram": telegram,
             "Cleaner": Cleaner,
+            "multi_livechat": multi_livechat_context,
         }


### PR DESCRIPTION
В предыдущем PR https://github.com/itpp-labs/sync-addons/pull/390 я написал:

> В дальнейшем надо бы в sync_telegram использовать post_channel_message от multi_livechat и расширить тот-же post_channel_message по необходимости.

Этот PR делает цитируемое.