### PR TITLE
[15.0][FIX] openapi access right issue when saving an ir.exports record

### DIFF
--- a/openapi/models/ir_exports.py
+++ b/openapi/models/ir_exports.py
@@ -9,7 +9,7 @@ class IrExports(models.Model):
     @api.constrains("resource", "export_fields")
     def _check_fields(self):
         # this exports record used in openapi.access
-        if not self.env["openapi.access"].search_count(
+        if not self.env["openapi.access"].sudo().search_count(
             ["|", ("read_one_id", "=", self.id), ("read_many_id", "=", self.id)]
         ):
             return True


### PR DESCRIPTION
In module openapi, the constraint method `_check_fields` of model `ir.exports` can only execute if the active user belongs to at least the group OpenAPI: User (Ext.ID: `openapi.group_user`).

However, as this constraint is called each time an `ir.exports` record is saved, this prevents any regular user from creating any export template, which seems incorrect. See attached screenshots:

![48887 (1920×492)](https://user-images.githubusercontent.com/8192093/210645335-960d6320-ba9f-4949-8208-4083440a626b.png)

![Screenshot 2023-01-03 at 15 12 07](https://user-images.githubusercontent.com/8192093/210645572-eec23e63-df9a-4200-9777-011c7b3903fd.png)


This PR proposes to fix this issue by calling the `sudo()` method before searching for `openapi.access` records.
