### PR TITLE
:ambulance: sync: return None when dynamic field not yet created

### DIFF
--- a/sync/models/base.py
+++ b/sync/models/base.py
@@ -161,9 +161,7 @@ class Base(models.AbstractModel):
         )
 
         if not field:
-            raise exceptions.UserError(
-                f"Field '{field_name}' not found for the current model '{self._name}'."
-            )
+            return None
 
         res_id = f"{self._name},{self.id}"
         prop = Property.search(


### PR DESCRIPTION
On reading property it's not a error if field is not created, it just mean that the property was never set before.