### PR TITLE
:ambulance: sync: fix reference fields

### DIFF
--- a/sync/models/sync_order.py
+++ b/sync/models/sync_order.py
@@ -18,12 +18,6 @@ class SyncOrder(models.Model):
     )
     sync_job_id = fields.Many2one("sync.job")
     description = fields.Html(related="sync_task_id.sync_order_description")
-    # DEPRECATED. Use line_ids.record_id instead
-    record_id = fields.Reference(
-        string="Blackjack",
-        selection="_selection_record_id",
-        help="Optional extra information to perform this task",
-    )
     line_ids = fields.One2many(
         "sync.order.line", "sync_order_id", string="Linked Records"
     )
@@ -38,12 +32,6 @@ class SyncOrder(models.Model):
         ],
         default="draft",
     )
-
-    def _selection_record_id(self):
-        mm = self.sync_task_id.sync_order_model_id
-        if not mm:
-            return []
-        return [(mm.model, mm.name)]
 
     def action_done(self):
         self.write({"state": "done"})
@@ -64,9 +52,10 @@ class SyncOrderLine(models.Model):
     _description = "Sync Order Records"
 
     sync_order_id = fields.Many2one("sync.order")
-    record_id = fields.Reference(
+    record_ref = fields.Reference(
         string="Linked Record",
-        selection="_selection_record_id",
+        selection=lambda self: self.selection_record_ref(),
+        required=True,
         help="Optional extra information to perform this task",
     )
     state = fields.Selection(
@@ -82,11 +71,8 @@ class SyncOrderLine(models.Model):
     value = fields.Char("Extra Input")
     result = fields.Char("Result")
 
-    def _selection_record_id(self):
-        mm = self.sync_order_id.sync_task_id.sync_order_model_id
-        if not mm:
-            return []
-        return [(mm.model, mm.name)]
+    def selection_record_ref(self):
+        return []
 
     def action_done(self, msg=None):
         self.write({"state": "done"})

--- a/sync/models/sync_project.py
+++ b/sync/models/sync_project.py
@@ -708,9 +708,15 @@ class SyncProject(models.Model):
                             "{TASK_ID}", str(task.id)
                         )
 
-                create_trigger(
+                automation = create_trigger(
                     "sync.trigger.automation", dict(data, model_id=model.id, model=None)
                 )
+                # fix recomputation
+                if data.get("trigger_field_ids"):
+                    automation.trigger_field_ids = data.get("trigger_field_ids")
+                for field_name in ("filter_pre_domain", "filter_domain"):
+                    if data.get(field_name):
+                        automation[field_name] = data.get(field_name)
 
         self.update(vals)
 

--- a/sync/views/sync_order_views.xml
+++ b/sync/views/sync_order_views.xml
@@ -9,7 +9,6 @@
             <tree>
                 <field name="sync_task_id" />
                 <field name="name" />
-                <field name="record_id" />
                 <field name="state" />
             </tree>
         </field>
@@ -66,10 +65,10 @@
                         <page string="Linked Records">
                             <field name="line_ids">
                                 <tree editable="bottom">
-                                    <field name="record_id" />
+                                    <field name="record_ref" />
                                     <field name="value" />
-                                    <field name="state" readonly="1" />
                                     <field name="result" readonly="1" />
+                                    <field name="state" readonly="1" />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
It turned out that selection models for the reference fields cannot be dynamic.

Also, delete deprecated field in sync.order because it didn't work anyway.