### PR TITLE
[IMP] sync: always show Refresh button once sync.order is confirmed

### DIFF
--- a/sync/models/sync_order.py
+++ b/sync/models/sync_order.py
@@ -17,6 +17,9 @@ class SyncOrder(models.Model):
         required=True,
     )
     sync_job_id = fields.Many2one("sync.job")
+    sync_job_state = fields.Selection(
+        related="sync_job_id.state", string="Sync Job State"
+    )
     description = fields.Html(related="sync_task_id.sync_order_description")
     line_ids = fields.One2many(
         "sync.order.line", "sync_order_id", string="Linked Records"

--- a/sync/views/sync_order_views.xml
+++ b/sync/views/sync_order_views.xml
@@ -31,7 +31,7 @@
                         string="Refresh"
                         name="action_refresh"
                         type="object"
-                        invisible="state != 'open'"
+                        invisible="state == 'draft'"
                     />
                     <button
                         string="Cancel"

--- a/sync/views/sync_order_views.xml
+++ b/sync/views/sync_order_views.xml
@@ -59,6 +59,7 @@
                         </group>
                         <group>
                             <field name="sync_job_id" readonly="1" />
+                            <field name="sync_job_state" readonly="1" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
This prevents accidential clicking Cancel or other button after moving state from "in progress".